### PR TITLE
Lv userprofiles

### DIFF
--- a/SQL/LV_UserProfile_Seed_Data.sql
+++ b/SQL/LV_UserProfile_Seed_Data.sql
@@ -1,0 +1,6 @@
+﻿INSERT INTO UserProfile ([FirstName], [LastName], [DisplayName], [Email], [CreateDateTime], [ImageLocation], [UserTypeId])
+VALUES ('John', 'Doe', 'johnnyboy', 'johndoe@example.com', SYSDATETIME(), NULL, 2);
+
+INSERT INTO UserProfile ([FirstName], [LastName], [DisplayName], [Email], [CreateDateTime], [ImageLocation], [UserTypeId])
+VALUES ('Jane', 'Doe', 'plainjane', 'janedoe@example.com', SYSDATETIME(), NULL, 2);
+

--- a/TabloidMVC/Controllers/AccountController.cs
+++ b/TabloidMVC/Controllers/AccountController.cs
@@ -38,6 +38,7 @@ namespace TabloidMVC.Controllers
             {
                 new Claim(ClaimTypes.NameIdentifier, userProfile.Id.ToString()),
                 new Claim(ClaimTypes.Email, userProfile.Email),
+                new Claim("UserType", userProfile.UserTypeId.ToString())
             };
 
             var claimsIdentity = new ClaimsIdentity(

--- a/TabloidMVC/Controllers/UserProfileController.cs
+++ b/TabloidMVC/Controllers/UserProfileController.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
 using TabloidMVC.Repositories;
 
 namespace TabloidMVC.Controllers
@@ -15,10 +17,20 @@ namespace TabloidMVC.Controllers
         }
 
         // GET: UserProfileController
+        [Authorize]
         public ActionResult Index()
         {
+            var currentUser = _userProfileRepo.GetById(GetCurrentUserId());
             var userProfiles = _userProfileRepo.GetAllUserProfiles();
-            return View(userProfiles);
+            if (_userProfileRepo.IsAdmin(currentUser))
+            {
+                return View(userProfiles);
+            }
+            else
+            {
+                return NotFound("Not authorized as admin");
+            }
+            ;
         }
 
         // GET: UserProfileController/Details/5
@@ -90,8 +102,11 @@ namespace TabloidMVC.Controllers
             }
         }
 
-       
+        private int GetCurrentUserId()
+        {
+            string userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            return int.Parse(userId);
+        }
 
-     
     }
 }

--- a/TabloidMVC/Controllers/UserProfileController.cs
+++ b/TabloidMVC/Controllers/UserProfileController.cs
@@ -1,0 +1,97 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using TabloidMVC.Repositories;
+
+namespace TabloidMVC.Controllers
+{
+    public class UserProfileController : Controller
+    {
+
+        private readonly IUserProfileRepository _userProfileRepo;
+
+        public UserProfileController(IUserProfileRepository userProfileRepository)
+        {
+            _userProfileRepo = userProfileRepository;
+        }
+
+        // GET: UserProfileController
+        public ActionResult Index()
+        {
+            var userProfiles = _userProfileRepo.GetAllUserProfiles();
+            return View(userProfiles);
+        }
+
+        // GET: UserProfileController/Details/5
+        public ActionResult Details(int id)
+        {
+            return View();
+        }
+
+        // GET: UserProfileController/Create
+        public ActionResult Create()
+        {
+            return View();
+        }
+
+        // POST: UserProfileController/Create
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Create(IFormCollection collection)
+        {
+            try
+            {
+                return RedirectToAction(nameof(Index));
+            }
+            catch
+            {
+                return View();
+            }
+        }
+
+        // GET: UserProfileController/Edit/5
+        public ActionResult Edit(int id)
+        {
+            return View();
+        }
+
+        // POST: UserProfileController/Edit/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Edit(int id, IFormCollection collection)
+        {
+            try
+            {
+                return RedirectToAction(nameof(Index));
+            }
+            catch
+            {
+                return View();
+            }
+        }
+
+        // GET: UserProfileController/Delete/5
+        public ActionResult Delete(int id)
+        {
+            return View();
+        }
+
+        // POST: UserProfileController/Delete/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Delete(int id, IFormCollection collection)
+        {
+            try
+            {
+                return RedirectToAction(nameof(Index));
+            }
+            catch
+            {
+                return View();
+            }
+        }
+
+       
+
+     
+    }
+}

--- a/TabloidMVC/Models/UserProfile.cs
+++ b/TabloidMVC/Models/UserProfile.cs
@@ -1,16 +1,21 @@
-﻿namespace TabloidMVC.Models
+﻿using System.ComponentModel;
+
+namespace TabloidMVC.Models
 {
     public class UserProfile
     {
         public int Id { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
+        [DisplayName("Display Name")]
         public string DisplayName { get; set; }
         public string Email { get; set; }
         public DateTime CreateDateTime { get; set; }
         public string ImageLocation { get; set; }
         public int UserTypeId { get; set; }
         public UserType UserType { get; set; }
+
+        [DisplayName("Full Name")]
         public string FullName
         {
             get

--- a/TabloidMVC/Models/UserType.cs
+++ b/TabloidMVC/Models/UserType.cs
@@ -1,8 +1,11 @@
-﻿namespace TabloidMVC.Models
+﻿using System.ComponentModel;
+
+namespace TabloidMVC.Models
 {
     public class UserType
     {
         public int Id { get; set; }
+        [DisplayName("User Type")]
         public string Name { get; set; }
 
     }

--- a/TabloidMVC/Repositories/IUserProfileRepository.cs
+++ b/TabloidMVC/Repositories/IUserProfileRepository.cs
@@ -5,6 +5,8 @@ namespace TabloidMVC.Repositories
     public interface IUserProfileRepository
     {
         UserProfile GetByEmail(string email);
+        UserProfile GetById(int id);
         List <UserProfile> GetAllUserProfiles();
+        bool IsAdmin(UserProfile userProfile);
     }
 }

--- a/TabloidMVC/Repositories/IUserProfileRepository.cs
+++ b/TabloidMVC/Repositories/IUserProfileRepository.cs
@@ -5,5 +5,6 @@ namespace TabloidMVC.Repositories
     public interface IUserProfileRepository
     {
         UserProfile GetByEmail(string email);
+        List <UserProfile> GetAllUserProfiles();
     }
 }

--- a/TabloidMVC/Repositories/UserProfileRepository.cs
+++ b/TabloidMVC/Repositories/UserProfileRepository.cs
@@ -53,5 +53,55 @@ namespace TabloidMVC.Repositories
                 }
             }
         }
+
+        public List<UserProfile> GetAllUserProfiles()
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                       SELECT u.id, u.FirstName, u.LastName, u.DisplayName, u.Email,
+                              u.CreateDateTime, u.ImageLocation, u.UserTypeId,
+                              ut.[Name] AS UserTypeName
+                         FROM UserProfile u
+                              LEFT JOIN UserType ut ON u.UserTypeId = ut.id
+                              ORDER BY u.DisplayName";
+                        
+                   
+
+                    UserProfile userProfile = null;
+                    var reader = cmd.ExecuteReader();
+
+                    var userProfiles = new List<UserProfile>();
+
+                    while (reader.Read())
+                    {
+                        userProfile = new UserProfile()
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Email = reader.GetString(reader.GetOrdinal("Email")),
+                            FirstName = reader.GetString(reader.GetOrdinal("FirstName")),
+                            LastName = reader.GetString(reader.GetOrdinal("LastName")),
+                            DisplayName = reader.GetString(reader.GetOrdinal("DisplayName")),
+                            CreateDateTime = reader.GetDateTime(reader.GetOrdinal("CreateDateTime")),
+                            ImageLocation = DbUtils.GetNullableString(reader, "ImageLocation"),
+                            UserTypeId = reader.GetInt32(reader.GetOrdinal("UserTypeId")),
+                            UserType = new UserType()
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("UserTypeId")),
+                                Name = reader.GetString(reader.GetOrdinal("UserTypeName"))
+                            },
+                        };
+                        userProfiles.Add(userProfile);
+                    }
+
+                    reader.Close();
+
+                    return userProfiles;
+                }
+            }
+        }
     }
-}
+    }

--- a/TabloidMVC/Repositories/UserProfileRepository.cs
+++ b/TabloidMVC/Repositories/UserProfileRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
+using System.Security.Claims;
 using TabloidMVC.Models;
 using TabloidMVC.Utils;
 
@@ -23,6 +24,52 @@ namespace TabloidMVC.Repositories
                               LEFT JOIN UserType ut ON u.UserTypeId = ut.id
                         WHERE email = @email";
                     cmd.Parameters.AddWithValue("@email", email);
+
+                    UserProfile userProfile = null;
+                    var reader = cmd.ExecuteReader();
+
+                    if (reader.Read())
+                    {
+                        userProfile = new UserProfile()
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Email = reader.GetString(reader.GetOrdinal("Email")),
+                            FirstName = reader.GetString(reader.GetOrdinal("FirstName")),
+                            LastName = reader.GetString(reader.GetOrdinal("LastName")),
+                            DisplayName = reader.GetString(reader.GetOrdinal("DisplayName")),
+                            CreateDateTime = reader.GetDateTime(reader.GetOrdinal("CreateDateTime")),
+                            ImageLocation = DbUtils.GetNullableString(reader, "ImageLocation"),
+                            UserTypeId = reader.GetInt32(reader.GetOrdinal("UserTypeId")),
+                            UserType = new UserType()
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("UserTypeId")),
+                                Name = reader.GetString(reader.GetOrdinal("UserTypeName"))
+                            },
+                        };
+                    }
+
+                    reader.Close();
+
+                    return userProfile;
+                }
+            }
+        }
+
+        public UserProfile GetById(int id)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                       SELECT u.id, u.FirstName, u.LastName, u.DisplayName, u.Email,
+                              u.CreateDateTime, u.ImageLocation, u.UserTypeId,
+                              ut.[Name] AS UserTypeName
+                         FROM UserProfile u
+                              LEFT JOIN UserType ut ON u.UserTypeId = ut.id
+                        WHERE u.id = @id";
+                    cmd.Parameters.AddWithValue("@id", id);
 
                     UserProfile userProfile = null;
                     var reader = cmd.ExecuteReader();
@@ -101,6 +148,19 @@ namespace TabloidMVC.Repositories
 
                     return userProfiles;
                 }
+            }
+        }
+     
+
+        public bool IsAdmin(UserProfile user)
+        {
+            if (user.UserTypeId == 1)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
             }
         }
     }

--- a/TabloidMVC/TabloidMVC.csproj
+++ b/TabloidMVC/TabloidMVC.csproj
@@ -7,8 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Components.QuickGrid.EntityFrameworkAdapter" Version="8.0.1" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.16" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/TabloidMVC/Views/Shared/_Layout.cshtml
+++ b/TabloidMVC/Views/Shared/_Layout.cshtml
@@ -28,9 +28,12 @@
                             <li class="nav-item ">
                                 <a class="nav-link  rounded " asp-area="" asp-controller="Post" asp-action="Index">POSTS</a>
                             </li>
-                            <li class="nav-item ">
-                                <a class="nav-link  rounded " asp-area="" asp-controller="UserProfile" asp-action="Index">USER PROFILES</a>
-                            </li>
+                            @if (User.FindFirst("UserType").Value == "1")
+                            {
+                                <li class="nav-item ">
+                                    <a class="nav-link  rounded " asp-area="" asp-controller="UserProfile" asp-action="Index">USER PROFILES</a>
+                                </li>
+                            }
                             <li class="nav-item ">
                                 <a class="nav-link  rounded " asp-area="" asp-controller="Account" asp-action="Logout">LOGOUT</a>
                             </li>

--- a/TabloidMVC/Views/Shared/_Layout.cshtml
+++ b/TabloidMVC/Views/Shared/_Layout.cshtml
@@ -29,6 +29,9 @@
                                 <a class="nav-link  rounded " asp-area="" asp-controller="Post" asp-action="Index">POSTS</a>
                             </li>
                             <li class="nav-item ">
+                                <a class="nav-link  rounded " asp-area="" asp-controller="UserProfile" asp-action="Index">USER PROFILES</a>
+                            </li>
+                            <li class="nav-item ">
                                 <a class="nav-link  rounded " asp-area="" asp-controller="Account" asp-action="Logout">LOGOUT</a>
                             </li>
                         }

--- a/TabloidMVC/Views/UserProfile/Index.cshtml
+++ b/TabloidMVC/Views/UserProfile/Index.cshtml
@@ -1,0 +1,53 @@
+﻿@model IEnumerable<TabloidMVC.Models.UserProfile>
+
+@{
+    ViewData["Title"] = "Index";
+}
+
+<h1>Index</h1>
+
+<p>
+    <a asp-action="Create">Create New</a>
+</p>
+<table class="table">
+    <thead>
+        <tr>
+            <th>
+                @Html.DisplayNameFor(model => model.Id)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.FullName)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.DisplayName)
+            </th>
+            <th>
+                @Html.DisplayNameFor(model => model.UserType.Name)
+            </th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+@foreach (var item in Model) {
+        <tr>
+            <td>
+                @Html.DisplayFor(modelItem => item.Id)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.FullName)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.DisplayName)
+            </td>
+            <td>
+                @Html.DisplayFor(modelItem => item.UserType.Name)
+            </td>
+            <td>
+                @Html.ActionLink("Edit", "Edit", new { id = item.Id  }) |
+                    @Html.ActionLink("Details", "Details", new { id = item.Id }) |
+                    @Html.ActionLink("Delete", "Delete", new { id = item.Id })
+            </td>
+        </tr>
+}
+    </tbody>
+</table>


### PR DESCRIPTION
# Description

Added a user profile navbar item that is only accessible to admins to see all user profiles ordered by their display name.

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)


# Testing Instructions

1. `git add` and `git commit` whatever you're working on in your branch
2.  `git checkout main`
3.  `git fetch --a`
4. `git checkout lv-userprofiles`
5.  if you don't see the most recent version of my file `git pull origin lv-userprofiles`
6. Open and execute the [LV_UserProfile_Seed_Data.sql](SQL/LV_UserProfile_Seed_Data.sql) file to create more user seed data
7. Open the TabloidMVC.Sln with Visual Studio
8. run the program
9. login with admin@example.com
10. click on USER PROFILES in the navbar
11. see that the program returns 3 user profiles in order by their display name (Admina Strator, John Doe, Jane Doe)
12. log out
13. log in with either johndoe@example.com or janedoe@example.com
14. confirm that USER PROFILES is no longer an option in the navbar

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
